### PR TITLE
Feature/add testing badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,11 @@ before_install:
   - sudo apt-get install -qq libsqlite3-dev libxml2 libxml2-dev libssl-dev libbz2-dev wget curl llvm
 install:
   - pip install -r requirements/local.txt
+  - pip install coveralls
 script:
   - py.test --cov-report=
+after_success:
+  - coveralls
 language: python
 python:
 - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 install:
   - pip install -r requirements/local.txt
 script:
-  - py.test
+  - py.test --cov-report=
 language: python
 python:
 - "3.5"

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,8 @@ rovercode-web
 .. image:: https://img.shields.io/badge/built%20with-Cookiecutter%20Django-ff69b4.svg
       :target: https://github.com/pydanny/cookiecutter-django/
       :alt: Built with Cookiecutter Django
+.. image:: https://api.travis-ci.org/aninternetof/rovercode-web.svg?branch=development
+      :target: https://travis-ci.org/aninternetof/rovercode-web
 
 rovercode is easy-to-use package for controlling robots (rovers) that can sense and react to their environment. The Blockly editor makes it easy to program and run your bot straight from your browser. Just drag and drop your commands to drive motors, read values from a variety of supported sensors, and see what your rover sees with the built in webcam viewer.
 rovercode runs on any single-board-computer supported by the `Adafruit Python GPIO wrapper library <https://github.com/adafruit/Adafruit_Python_GPIO>`_, including the NextThingCo CHIP, Raspberry Pi, and BeagleBone Black. Once installed, just connect to your rover and get started.

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,8 @@ rovercode-web
       :alt: Built with Cookiecutter Django
 .. image:: https://api.travis-ci.org/aninternetof/rovercode-web.svg?branch=development
       :target: https://travis-ci.org/aninternetof/rovercode-web
+.. image:: https://coveralls.io/repos/github/aninternetof/rovercode-web/badge.svg?branch=development
+      :target: https://coveralls.io/github/aninternetof/rovercode-web?branch=deveopment
 
 rovercode is easy-to-use package for controlling robots (rovers) that can sense and react to their environment. The Blockly editor makes it easy to program and run your bot straight from your browser. Just drag and drop your commands to drive motors, read values from a variety of supported sensors, and see what your rover sees with the built in webcam viewer.
 rovercode runs on any single-board-computer supported by the `Adafruit Python GPIO wrapper library <https://github.com/adafruit/Adafruit_Python_GPIO>`_, including the NextThingCo CHIP, Raspberry Pi, and BeagleBone Black. Once installed, just connect to your rover and get started.


### PR DESCRIPTION
Adds travis testing badge.
Sets up coveralls to provide us with a badge for coverage (https://coveralls.io/github/aninternetof/rovercode-web). I tested the coverage badge for this branch, but the badge for development will be unknown until we pull something into development.