### PR TITLE
Changes coverall svg url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ rovercode-web
 .. image:: https://img.shields.io/badge/built%20with-Cookiecutter%20Django-ff69b4.svg
       :target: https://github.com/pydanny/cookiecutter-django/
       :alt: Built with Cookiecutter Django
-.. image:: https://api.travis-ci.org/aninternetof/rovercode-web.svg?branch=development
+.. image:: https://api.travis-ci.org/aninternetof/rovercode-web.svg
       :target: https://travis-ci.org/aninternetof/rovercode-web
 .. image:: https://coveralls.io/repos/github/aninternetof/rovercode-web/badge.svg?branch=development
       :target: https://coveralls.io/github/aninternetof/rovercode-web?branch=deveopment


### PR DESCRIPTION
Coverall is being weird about the build status of the development branch. This will just specify no branch, and hopefully it chooses the default.