### PR TITLE
Reduce the size of images

### DIFF
--- a/compose/nginx/Dockerfile
+++ b/compose/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:latest
+FROM nginx:alpine
 ADD nginx.conf /etc/nginx/nginx.conf
 
 

--- a/compose/postgres/Dockerfile
+++ b/compose/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.6
+FROM postgres:9.6-alpine
 
 # add backup scripts
 ADD backup.sh /usr/local/bin/backup

--- a/dev.yml
+++ b/dev.yml
@@ -34,7 +34,7 @@ services:
       - mailhog
 
   redis:
-    image: redis:latest
+    image: redis:alpine
 
   celeryworker:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
 
 
   redis:
-    image: redis:latest
+    image: redis:alpine
 
 
   celeryworker:


### PR DESCRIPTION
Use the `alpine` version of official images since they are much smaller
and debugging won't be needed or other packages installed within them.

After merging, manually remove all of the older large images if desired.