### PR TITLE
Add page for logged in user to see user's block diagrams

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
 include = rovercode_web/*
-omit = *migrations*, *tests*
+omit = *migrations*, *tests*, *templates*
 plugins =
     django_coverage_plugin

--- a/mission_control/static/js/mission-control.js
+++ b/mission_control/static/js/mission-control.js
@@ -176,10 +176,10 @@ function setRoverIp(ip) {
 
 /*----- DESIGN SAVING/LOADING FUNCTIONS -----*/
 
-function chooseDesign() {
+function chooseDesign(userId) {
   $('#nameModal').modal('hide');
   $('#loadModal').modal('show');
-  refreshSavedBds();
+  refreshSavedBds(userId);
 }
 
 $('#uploadForm #fileToUpload').change(function(){

--- a/mission_control/static/js/rover-api.js
+++ b/mission_control/static/js/rover-api.js
@@ -28,21 +28,22 @@ function saveDesign() {
   });
 }
 
-function refreshSavedBds() {
-  $.get(roverResource('blockdiagrams'), function(json){
-    if (!json.result.length){
-      $('#savedDesignsArea').text("There are no designs saved on this rover");
+function refreshSavedBds(userId) {
+  $.get("/mission-control/block-diagrams/?user=" + userId, function(json){
+    if (!json.length){
+      $('#savedDesignsArea').text("There are no designs saved.");
     } else {
       $('#savedDesignsArea').empty();
-      json.result.forEach(function(entry) {
-        $(document.createElement('a')).addClass('button')
-        .html(entry)
-        .attr('href', '#')
-        .css('margin', '10px')
-        .appendTo($("#savedDesignsArea"))
-        .click(function() {
-          return loadDesign(entry);
-        });
+      $.each(json, function(index, entry) {
+        $(document.createElement('button'))
+          .addClass('btn btn-primary')
+          .text(entry.name)
+          .attr('href', '#')
+          .css('margin', '10px')
+          .appendTo($("#savedDesignsArea"))
+          .click(function() {
+            return loadDesign(entry);
+          });
       });
     }
   }

--- a/mission_control/templates/home.html
+++ b/mission_control/templates/home.html
@@ -69,7 +69,7 @@
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">File</a>
               <div class="dropdown-menu">
-                <a href="#" onclick="return chooseDesign()">Load Previous Design</a>
+                <a href="#" onclick="return chooseDesign({{ request.user.id }})">Load Previous Design</a>
                 <a href="#" onclick="$('#nameModal').modal()">Copy This Design</a>
                 <a href="#" id="downloadLink">Download This Design</a>
               </div>
@@ -165,7 +165,7 @@
             <div class="row text-md-center" style="padding-top: 40px; padding-bottom: 40px">
               <div class="col-md-12">
                 <h2>Or, load a saved design</h2>
-                <a role="button" onclick="return chooseDesign()" style="color: white;" class="btn btn-primary">Go</a>
+                <a role="button" onclick="return chooseDesign({{ request.user.id }})" style="color: white;" class="btn btn-primary">Go</a>
               </div>
             </div>
           </div>
@@ -181,7 +181,7 @@
           <div class="container-fluid">
             <div class="row" style="padding-top: 40px; padding-bottom: 40px">
               <div class="col-md-12">
-                <h2>Here are the designs saved on this rover:</h2>
+                <h2>Here are your saved designs:</h2>
                 <div class="panel" id="savedDesignsArea"></div>
               </div>
             </div>

--- a/mission_control/templates/list.html
+++ b/mission_control/templates/list.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block css %}
+  {{ block.super }}
+  <style>
+    .btn {
+      margin: 5px;
+    }
+  </style>
+{% endblock css %}
+
+{% block content %}
+  <div class="row">
+    <div class="col-md-12">
+      <h1>{{ request.user.username }}'s Block Diagrams:</h1>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-12 btn-group" id="bds">
+      {% for bd in bd_list %}
+        <button class="btn btn-primary">{{ bd.name }}</button>
+      {% endfor %}
+    </div>
+  </div>
+{% endblock content %}

--- a/mission_control/tests/test_urls.py
+++ b/mission_control/tests/test_urls.py
@@ -15,6 +15,18 @@ class TestMissionControlURLs(TestCase):
             resolve('/mission-control/').view_name,
             'mission-control:home')
 
+    def test_list_reverse(self):
+        """mission-control:list should reverse to /mission-control/list/."""
+        self.assertEqual(
+            reverse('mission-control:list'),
+            '/mission-control/list/')
+
+    def test_list_resolve(self):
+        """/mission-control/list/ should resolve to mission-control:list."""
+        self.assertEqual(
+            resolve('/mission-control/list/').view_name,
+            'mission-control:list')
+
     def test_rovers_reverse(self):
         """mission-control:rovers should reverse to /mission-control/rovers/."""
         self.assertEqual(

--- a/mission_control/tests/test_views.py
+++ b/mission_control/tests/test_views.py
@@ -69,3 +69,25 @@ class TestBlockDiagramViewSet(TestCase):
         self.assertEqual(response.json()[0]['user'], user.id)
         self.assertEqual(response.json()[0]['name'], 'test')
         self.assertEqual(response.json()[0]['content'], '<xml></xml>')
+
+    def test_bd_user_filter(self):
+        user1 = self.make_user('user1')
+        user2 = self.make_user('user2')
+        BlockDiagram.objects.create(
+            user=user1,
+            name='test1',
+            content='<xml></xml>'
+        )
+        bd2 = BlockDiagram.objects.create(
+            user=user2,
+            name='test2',
+            content='<xml></xml>'
+        )
+        response = self.get(
+            reverse(
+                'mission-control:blockdiagram-list') + '?user=' + str(user2.id))
+        self.assertEqual(1, len(response.json()))
+        self.assertEqual(response.json()[0]['id'], bd2.id)
+        self.assertEqual(response.json()[0]['user'], user2.id)
+        self.assertEqual(response.json()[0]['name'], 'test2')
+        self.assertEqual(response.json()[0]['content'], '<xml></xml>')

--- a/mission_control/urls.py
+++ b/mission_control/urls.py
@@ -12,5 +12,6 @@ router.register(r'block-diagrams', views.BlockDiagramViewSet)
 urlpatterns = [
     url(r'^$', views.home, name='home'),
     url(r'^', include(router.urls)),
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+    url(r'^list/$', views.list, name='list'),
 ]

--- a/mission_control/views.py
+++ b/mission_control/views.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 from .models import Rover, BlockDiagram
-from rest_framework import viewsets
+from rest_framework import filters, viewsets
 from .serializers import RoverSerializer, BlockDiagramSerializer
 
 
@@ -29,3 +29,5 @@ class BlockDiagramViewSet(viewsets.ModelViewSet):
     """
     queryset = BlockDiagram.objects.all()
     serializer_class = BlockDiagramSerializer
+    filter_backends = (filters.DjangoFilterBackend,)
+    filter_fields = ('user',)

--- a/mission_control/views.py
+++ b/mission_control/views.py
@@ -1,10 +1,19 @@
+from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 from .models import Rover, BlockDiagram
 from rest_framework import viewsets
 from .serializers import RoverSerializer, BlockDiagramSerializer
 
+
 def home(request):
     return render(request, 'home.html')
+
+
+@login_required
+def list(request):
+    bd_list = BlockDiagram.objects.filter(user=request.user.id)
+    return render(request, 'list.html', {'bd_list': bd_list})
+
 
 class RoverViewSet(viewsets.ModelViewSet):
     """

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -7,6 +7,7 @@ django-extensions==1.7.5
 Werkzeug==0.11.15
 django-test-plus==1.0.16
 factory-boy==2.8.1
+django-filter==1.0.1
 
 django-debug-toolbar==1.6
 

--- a/rovercode_web/templates/base.html
+++ b/rovercode_web/templates/base.html
@@ -43,6 +43,9 @@
             <ul class="nav navbar-nav pull-xs-right">
               {% if request.user.is_authenticated %}
                 <li class="nav-item">
+                  <a class="nav-link" href="{% url 'mission-control:list' %}">{% trans "My Block Diagrams" %}</a>
+                </li>
+                <li class="nav-item">
                   <a class="nav-link" href="{% url 'users:detail' request.user.username  %}">{% trans "My Profile" %}</a>
                 </li>
                 <li class="nav-item">


### PR DESCRIPTION
Addresses issue #3 

Creates a page that lists all of the logged in user's block diagrams. Hopefully someone with more artistic talent can make it look better, but all of the data is there. The block diagram buttons currently don't go anywhere. I'm not sure how that's going to tie into the blockly interface.

When a user is logged in, the `My Block Diagrams` navbar button is visible:
![header](https://cloud.githubusercontent.com/assets/1184314/23006318/0bbcb180-f3cf-11e6-80ee-18c060fc47f6.png)

When clicked, takes the user to a page listing only the block diagrams created by that user:
![list](https://cloud.githubusercontent.com/assets/1184314/23006322/10ace23c-f3cf-11e6-96f4-b316ebda5276.png)
