### PR TITLE
Configures coverage to check multiple directories

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
 source = rovercode_web/, mission_control/
-omit = *migrations*, *tests*, *templates*
+omit = *migrations*, *tests*, *templates*, *static*
 plugins =
     django_coverage_plugin

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-include = rovercode_web/*
+source = rovercode_web/, mission_control/
 omit = *migrations*, *tests*, *templates*
 plugins =
     django_coverage_plugin

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -48,7 +48,7 @@ LOCAL_APPS = (
     # custom users app
     'rovercode_web.users.apps.UsersConfig',
     # Your stuff: custom apps go here
-    'mission_control'
+    'mission_control.apps.MissionControlConfig'
 )
 
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#installed-apps

--- a/mission_control/tests/test_views.py
+++ b/mission_control/tests/test_views.py
@@ -6,6 +6,12 @@ from django.core.urlresolvers import reverse
 from mission_control.models import Rover, BlockDiagram
 
 
+class TestHomeView(TestCase):
+    def test_home(self):
+        response = self.get(reverse('mission-control:home'))
+        self.assertEqual(200, response.status_code)
+
+
 class TestListView(TestCase):
     def setUp(self):
         self.admin = get_user_model().objects.create(username='administrator')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=config.settings.local
-addopts = --strict --cov rovercode_web --cov-report term-missing --cov-report html
+addopts = --strict --cov --cov-report term-missing --cov-report html


### PR DESCRIPTION
Configures coverage so that now the `.coveragerc` determines which directories are being checked. Both the `rovercode_web` and `mission_control` directories are now included. A couple of tests were missing for `mission_control` that are now added to bring the coverage back to 100%.