### PR TITLE
Select the correct Django filter backend

### DIFF
--- a/mission_control/views.py
+++ b/mission_control/views.py
@@ -1,7 +1,8 @@
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
+from django_filters.rest_framework import DjangoFilterBackend
 from .models import Rover, BlockDiagram
-from rest_framework import filters, viewsets
+from rest_framework import viewsets
 from rest_framework.response import Response
 from .serializers import RoverSerializer, BlockDiagramSerializer
 from mission_control.utils import remove_old_rovers
@@ -31,11 +32,12 @@ class RoverViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
 
+
 class BlockDiagramViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows block diagrams to be viewed or edited.
     """
     queryset = BlockDiagram.objects.all()
     serializer_class = BlockDiagramSerializer
-    filter_backends = (filters.DjangoFilterBackend,)
+    filter_backends = (DjangoFilterBackend,)
     filter_fields = ('user',)


### PR DESCRIPTION
The `django-filters` `DjangoFilterBackend` provides a nice `Filters` button
on the browsable API.

![button](https://cloud.githubusercontent.com/assets/1184314/23241351/9eabfbf6-f940-11e6-98fb-df888bd8ffaa.png)
![modal](https://cloud.githubusercontent.com/assets/1184314/23241357/a3bc4524-f940-11e6-8769-f1c920283ba1.png)
