### PR TITLE
Moves django-filters from local to base

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -46,3 +46,4 @@ redis>=2.10.5
 
 # Your custom requirements go here
 djangorestframework~=3.5.3
+django-filter==1.0.1

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -7,7 +7,6 @@ django-extensions==1.7.5
 Werkzeug==0.11.15
 django-test-plus==1.0.16
 factory-boy==2.8.1
-django-filter==1.0.1
 
 django-debug-toolbar==1.6
 


### PR DESCRIPTION
I think the django-filters requirement needs to be in base so that the production build has it, too.