### PR TITLE
Add Python linting check

### DIFF
--- a/.prospector.yaml
+++ b/.prospector.yaml
@@ -1,0 +1,21 @@
+strictness: veryhigh
+doc-warnings: true
+test-warnings: true
+
+ignore-paths:
+  - mission_control/static/
+  - mission_control/migrations/
+  - rovercode_web/users/
+  - rovercode_web/contrib/
+  - config/
+  - docs/
+  - manage.py
+
+pep8:
+  full: true
+
+pep257:
+  run: true
+  disable:
+    # 1 blank line required before class docstring
+    - D203

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - pip install coveralls
 script:
   - py.test --cov-report=
+  - prospector
 after_success:
   - coveralls
 language: python

--- a/mission_control/__init__.py
+++ b/mission_control/__init__.py
@@ -1,0 +1,1 @@
+"""Mission Control app."""

--- a/mission_control/admin.py
+++ b/mission_control/admin.py
@@ -1,3 +1,0 @@
-from django.contrib import admin
-
-# Register your models here.

--- a/mission_control/apps.py
+++ b/mission_control/apps.py
@@ -1,5 +1,8 @@
+"""Mission Control apps."""
 from django.apps import AppConfig
 
 
 class MissionControlConfig(AppConfig):
+    """Configuration for the Mission Control app."""
+
     name = 'mission_control'

--- a/mission_control/models.py
+++ b/mission_control/models.py
@@ -1,20 +1,28 @@
+"""Mission Control models."""
 from django.db import models
 from rovercode_web.users.models import User
 
+
 class Rover(models.Model):
+    """Attributes to describe a single rover."""
+
     name = models.TextField()
     owner = models.TextField()
     local_ip = models.TextField()
     last_checkin = models.DateTimeField(auto_now=True)
 
     def __str__(self):
+        """Convert the model to a human readable string."""
         return self.name
 
 
 class BlockDiagram(models.Model):
+    """Attributes to describe a single block diagram."""
+
     user = models.ForeignKey(User)
     name = models.TextField()
     content = models.TextField()
 
     def __str__(self):
+        """Convert the model to a human readable string."""
         return self.name

--- a/mission_control/serializers.py
+++ b/mission_control/serializers.py
@@ -1,13 +1,23 @@
+"""Mission Control serializers."""
 from .models import Rover, BlockDiagram
 from rest_framework import serializers
 
+
 class RoverSerializer(serializers.HyperlinkedModelSerializer):
+    """Rover model serializer."""
+
     class Meta:
+        """Meta class."""
+
         model = Rover
         fields = ('id', 'name', 'owner', 'local_ip', 'last_checkin')
 
 
 class BlockDiagramSerializer(serializers.ModelSerializer):
+    """Block diagram model serializer."""
+
     class Meta:
+        """Meta class."""
+
         model = BlockDiagram
         fields = ('id', 'user', 'name', 'content')

--- a/mission_control/tests.py
+++ b/mission_control/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/mission_control/tests/test_models.py
+++ b/mission_control/tests/test_models.py
@@ -1,11 +1,14 @@
+"""Mission Control test models."""
 from test_plus.test import TestCase
 
 from mission_control.models import Rover, BlockDiagram
 
 
 class TestRover(TestCase):
+    """Tests the Rover model."""
 
     def test__str__(self):
+        """Test the stringify method."""
         self.rover = Rover.objects.create(
             name='rover',
             owner='jimbo',
@@ -15,8 +18,10 @@ class TestRover(TestCase):
 
 
 class TestBlockDiagram(TestCase):
+    """Tests the block diagram model."""
 
     def setUp(self):
+        """Setup the tests."""
         self.user = self.make_user()
         self.bd = BlockDiagram.objects.create(
             user=self.user,
@@ -25,8 +30,10 @@ class TestBlockDiagram(TestCase):
         )
 
     def test__str__(self):
+        """Test the stringify method."""
         self.assertEqual(str(self.bd), 'test')
 
     def test_bd(self):
+        """Test the model."""
         self.assertEqual(1, BlockDiagram.objects.count())
         self.assertEqual(self.user.id, BlockDiagram.objects.first().user.id)

--- a/mission_control/tests/test_urls.py
+++ b/mission_control/tests/test_urls.py
@@ -1,9 +1,11 @@
+"""Mission Control test urls."""
 from django.core.urlresolvers import reverse, resolve
 
 from test_plus.test import TestCase
 
 
 class TestMissionControlURLs(TestCase):
+    """Tests the urls."""
 
     def test_home_reverse(self):
         """mission-control:home should reverse to /mission-control/."""
@@ -28,25 +30,25 @@ class TestMissionControlURLs(TestCase):
             'mission-control:list')
 
     def test_rovers_reverse(self):
-        """mission-control:rovers should reverse to /mission-control/rovers/."""
+        """mission-control:rover-list should reverse to /mission-control/rovers/.""" #noqa
         self.assertEqual(
             reverse('mission-control:rover-list'),
             '/mission-control/rovers/')
 
     def test_rovers_resolve(self):
-        """/mission-control/rovers/ should resolve to mission-control:rover-list."""
+        """/mission-control/rovers/ should resolve to mission-control:rover-list.""" #noqa
         self.assertEqual(
             resolve('/mission-control/rovers/').view_name,
             'mission-control:rover-list')
 
     def test_block_diagrams_reverse(self):
-        """mission-control:blockdiagram-list should reverse to /mission-control/block-diagrams/."""
+        """mission-control:blockdiagram-list should reverse to /mission-control/block-diagrams/.""" #noqa
         self.assertEqual(
             reverse('mission-control:blockdiagram-list'),
             '/mission-control/block-diagrams/')
 
     def test_block_diagrams_resolve(self):
-        """/mission-control/block-diagrams/ should resolve to mission-control:blockdiagram-list."""
+        """/mission-control/block-diagrams/ should resolve to mission-control:blockdiagram-list.""" #noqa
         self.assertEqual(
             resolve('/mission-control/block-diagrams/').view_name,
             'mission-control:blockdiagram-list')

--- a/mission_control/tests/test_utils.py
+++ b/mission_control/tests/test_utils.py
@@ -1,6 +1,5 @@
+"""Mission Control test utils."""
 from test_plus.test import TestCase
-
-from django.core.urlresolvers import reverse
 
 from mission_control.models import Rover
 from mission_control.utils import remove_old_rovers
@@ -8,9 +7,12 @@ from mission_control.utils import remove_old_rovers
 import time
 from datetime import timedelta
 
+
 class TestRemoveOldRovers(TestCase):
+    """Tests removing old rovers."""
 
     def test_rover(self):
+        """Test the remove_old_rovers method."""
         Rover.objects.create(
             name='rover',
             owner='jimbo',
@@ -23,5 +25,5 @@ class TestRemoveOldRovers(TestCase):
             owner='jimbo',
             local_ip='8.8.8.8'
         )
-        remove_old_rovers(timedelta(seconds=-1));
+        remove_old_rovers(timedelta(seconds=-1))
         self.assertEqual(1, Rover.objects.count())

--- a/mission_control/tests/test_views.py
+++ b/mission_control/tests/test_views.py
@@ -1,3 +1,4 @@
+"""Mission Control test views."""
 from test_plus.test import TestCase
 
 from django.contrib.auth import get_user_model
@@ -9,18 +10,25 @@ import time
 
 
 class TestHomeView(TestCase):
+    """Tests the home view."""
+
     def test_home(self):
+        """Test the home view."""
         response = self.get(reverse('mission-control:home'))
         self.assertEqual(200, response.status_code)
 
 
 class TestListView(TestCase):
+    """Tests the block diagram list view."""
+
     def setUp(self):
+        """Setup the tests."""
         self.admin = get_user_model().objects.create(username='administrator')
         self.admin.set_password('password')
         self.admin.save()
 
     def test_list(self):
+        """Test the block diagram list view displays the correct items."""
         self.client.login(username='administrator', password='password')
         user = self.make_user()
         bd1 = BlockDiagram.objects.create(
@@ -40,6 +48,7 @@ class TestListView(TestCase):
         self.assertNotContains(response, bd1.name)
 
     def test_list_not_logged_in(self):
+        """Test the block diagram list view redirects if no logged in user."""
         response = self.get(reverse('mission-control:list'))
         self.assertRedirects(
             response,
@@ -48,8 +57,10 @@ class TestListView(TestCase):
 
 
 class TestRoverViewSet(TestCase):
+    """Tests the rover API view."""
 
     def test_rover(self):
+        """Test the rover view displays the correct items."""
         Rover.objects.create(
             name='rover',
             owner='jimbo',
@@ -71,8 +82,10 @@ class TestRoverViewSet(TestCase):
 
 
 class TestBlockDiagramViewSet(TestCase):
+    """Tests the block diagram API view."""
 
     def test_bd(self):
+        """Test the block diagram API view displays the correct items."""
         user = self.make_user()
         bd = BlockDiagram.objects.create(
             user=user,
@@ -87,6 +100,7 @@ class TestBlockDiagramViewSet(TestCase):
         self.assertEqual(response.json()[0]['content'], '<xml></xml>')
 
     def test_bd_user_filter(self):
+        """Test the block diagram API view filters on user correctly."""
         user1 = self.make_user('user1')
         user2 = self.make_user('user2')
         BlockDiagram.objects.create(

--- a/mission_control/urls.py
+++ b/mission_control/urls.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-7 -*-
+"""Mission Control urls."""
 from __future__ import unicode_literals
 
 from django.conf.urls import include, url
@@ -12,6 +13,7 @@ router.register(r'block-diagrams', views.BlockDiagramViewSet)
 urlpatterns = [
     url(r'^$', views.home, name='home'),
     url(r'^', include(router.urls)),
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+    url(r'^api-auth/',
+        include('rest_framework.urls', namespace='rest_framework')),
     url(r'^list/$', views.list, name='list'),
 ]

--- a/mission_control/utils.py
+++ b/mission_control/utils.py
@@ -1,11 +1,17 @@
+"""Mission Control utils."""
 from .models import Rover
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
-"""
-Removes from the database all rovers who haven't checked in in a certain amount of time.
 
-:param age:
-A timedelta expressing the oldest rover to keep. Any older will be removed. Must be negative.
-"""
 def remove_old_rovers(age):
-    Rover.objects.filter(last_checkin__lte=(datetime.now(timezone.utc)+age)).delete()
+    """Remove inactive rovers from the database.
+
+    Rovers are determined to be inactive when they haven't checked in a certain
+    amount of time.
+
+    :param age:
+        A timedelta expressing the oldest rover to keep. Any older will be
+        removed. Must be negative.
+    """
+    Rover.objects.filter(
+        last_checkin__lte=(datetime.now(timezone.utc) + age)).delete()

--- a/mission_control/views.py
+++ b/mission_control/views.py
@@ -1,3 +1,4 @@
+"""Mission Control views."""
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 from django_filters.rest_framework import DjangoFilterBackend
@@ -10,23 +11,25 @@ from datetime import timedelta
 
 
 def home(request):
+    """Home view."""
     return render(request, 'home.html')
 
 
 @login_required
 def list(request):
+    """Block diagram list view for the logged in user."""
     bd_list = BlockDiagram.objects.filter(user=request.user.id)
     return render(request, 'list.html', {'bd_list': bd_list})
 
 
 class RoverViewSet(viewsets.ModelViewSet):
-    """
-    API endpoint that allows rovers to be viewed or edited.
-    """
+    """API endpoint that allows rovers to be viewed or edited."""
+
     queryset = Rover.objects.all()
     serializer_class = RoverSerializer
 
     def list(self, request):
+        """Remove old rovers and lists the remaining active rovers."""
         remove_old_rovers(timedelta(seconds=-5))
         queryset = Rover.objects.all()
         serializer = self.get_serializer(queryset, many=True)
@@ -34,9 +37,8 @@ class RoverViewSet(viewsets.ModelViewSet):
 
 
 class BlockDiagramViewSet(viewsets.ModelViewSet):
-    """
-    API endpoint that allows block diagrams to be viewed or edited.
-    """
+    """API endpoint that allows block diagrams to be viewed or edited."""
+
     queryset = BlockDiagram.objects.all()
     serializer_class = BlockDiagramSerializer
     filter_backends = (DjangoFilterBackend,)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -47,3 +47,4 @@ redis>=2.10.5
 # Your custom requirements go here
 djangorestframework~=3.5.3
 django-filter==1.0.1
+prospector==0.12.4

--- a/rovercode_web/__init__.py
+++ b/rovercode_web/__init__.py
@@ -1,3 +1,9 @@
 # -*- coding: utf-8 -*-
+"""rovercode web app."""
 __version__ = '0.1.0'
-__version_info__ = tuple([int(num) if num.isdigit() else num for num in __version__.replace('-', '.', 1).split('.')])
+__version_info__ = tuple(
+    [
+        int(num) if num.isdigit() else num for num in __version__
+        .replace('-', '.', 1).split('.')
+    ]
+)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,0 @@
-[flake8]
-max-line-length = 120
-exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules
-
-[pep8]
-max-line-length = 120
-exclude=.tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules


### PR DESCRIPTION
This uses [prospector](https://github.com/landscapeio/prospector) to check all of the python files against `dodgy`, `mccabe`, `pep257`, `pep8`, `pyflakes`, and `pylint`. All of the files have been updated to pass. Travis CI has been configured to run the check as part of testing.

To run manually:
```
sudo docker-compose -f dev.yml run django prospector
```