### PR TITLE
Includes csrf token more directly.

### DIFF
--- a/mission_control/static/js/mission-control.js
+++ b/mission_control/static/js/mission-control.js
@@ -19,23 +19,7 @@ sensorStateCache["SENSORS_leftIr"] = false;
 sensorStateCache["SENSORS_rightIr"] = false;
 
 /*----- INIT CODE -----*/
-/* Set up to use CSRF token */
-function getCookie(name) {
-  var cookieValue = null;
-  if (document.cookie && document.cookie !== '') {
-    var cookies = document.cookie.split(';');
-    for (var i = 0; i < cookies.length; i++) {
-      var cookie = jQuery.trim(cookies[i]);
-      // Does this cookie string begin with the name we want?
-      if (cookie.substring(0, name.length + 1) === (name + '=')) {
-        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-        break;
-      }
-    }
-  }
-  return cookieValue;
-}
-var csrftoken = getCookie('csrftoken');
+var csrftoken = jQuery("[name=csrfmiddlewaretoken]").val();
 function csrfSafeMethod(method) {
   // these HTTP methods do not require CSRF protection
   return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));

--- a/mission_control/templates/home.html
+++ b/mission_control/templates/home.html
@@ -315,6 +315,7 @@
     </category>
   </xml>
 
+  {% csrf_token %}
   <script src="{% static 'js/mission-control.js' %}"></script>
 
 </body>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -47,4 +47,5 @@ redis>=2.10.5
 # Your custom requirements go here
 djangorestframework~=3.5.3
 django-filter==1.0.1
+pylint==1.6.5
 prospector==0.12.4


### PR DESCRIPTION
When running in production, the csrf token was not available in the cookie. So, this includes it directly in the DOM as shown [here](https://docs.djangoproject.com/en/1.11/ref/csrf/#acquiring-the-token-if-csrf-use-sessions-is-true).
