### PR TITLE
Adds install of procps to nginx Dockerfile

### DIFF
--- a/compose/nginx/Dockerfile
+++ b/compose/nginx/Dockerfile
@@ -1,4 +1,6 @@
 FROM nginx:latest
+RUN apt-get update
+RUN apt-get install -y procps
 ADD nginx.conf /etc/nginx/nginx.conf
 
 
@@ -6,4 +8,3 @@ ADD start.sh /start.sh
 ADD nginx-secure.conf /etc/nginx/nginx-secure.conf
 ADD dhparams.pem /etc/ssl/private/dhparams.pem
 CMD /start.sh
-

--- a/compose/nginx/Dockerfile
+++ b/compose/nginx/Dockerfile
@@ -1,6 +1,4 @@
 FROM nginx:latest
-RUN apt-get update
-RUN apt-get install -y procps
 ADD nginx.conf /etc/nginx/nginx.conf
 
 
@@ -8,3 +6,4 @@ ADD start.sh /start.sh
 ADD nginx-secure.conf /etc/nginx/nginx-secure.conf
 ADD dhparams.pem /etc/ssl/private/dhparams.pem
 CMD /start.sh
+

--- a/compose/nginx/Dockerfile
+++ b/compose/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:latest
+FROM nginx:1.11.10
 ADD nginx.conf /etc/nginx/nginx.conf
 
 
@@ -6,4 +6,3 @@ ADD start.sh /start.sh
 ADD nginx-secure.conf /etc/nginx/nginx-secure.conf
 ADD dhparams.pem /etc/ssl/private/dhparams.pem
 CMD /start.sh
-


### PR DESCRIPTION
Not sure what changed about the official nginx Docker image, but suddenly `ps` was unavailable.