### PR TITLE
Load bds

### DIFF
--- a/compose/nginx/Dockerfile
+++ b/compose/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:latest
+FROM nginx:1.11.10
 ADD nginx.conf /etc/nginx/nginx.conf
 
 
@@ -6,4 +6,3 @@ ADD start.sh /start.sh
 ADD nginx-secure.conf /etc/nginx/nginx-secure.conf
 ADD dhparams.pem /etc/ssl/private/dhparams.pem
 CMD /start.sh
-

--- a/mission_control/static/js/mission-control.js
+++ b/mission_control/static/js/mission-control.js
@@ -70,8 +70,8 @@ var workspace = Blockly.inject(blocklyDiv,
 );
 workspace.addChangeListener(updateCode);
 workspace.addChangeListener(saveDesign);
-//loadDesign('event_handler_hidden');
-writeToConsole("RoverCode console started");
+loadDesignByName('event_handler_hidden');
+writeToConsole("rovercode console started");
 
 /* Handle Blockly resizing */
 var onresize = function(e) {

--- a/mission_control/views.py
+++ b/mission_control/views.py
@@ -44,4 +44,4 @@ class BlockDiagramViewSet(viewsets.ModelViewSet):
     queryset = BlockDiagram.objects.all()
     serializer_class = BlockDiagramSerializer
     filter_backends = (DjangoFilterBackend,)
-    filter_fields = ('user','name')
+    filter_fields = ('user', 'name')

--- a/mission_control/views.py
+++ b/mission_control/views.py
@@ -44,4 +44,4 @@ class BlockDiagramViewSet(viewsets.ModelViewSet):
     queryset = BlockDiagram.objects.all()
     serializer_class = BlockDiagramSerializer
     filter_backends = (DjangoFilterBackend,)
-    filter_fields = ('user',)
+    filter_fields = ('user','name')


### PR DESCRIPTION
Now we load block diagrams from the rovercode.com interface instead of from the rover's interface.

Also, made it pull in the base xml for all new block diagrams ('event_handler_hidden'). Simplest solution I could think of was just to search for it by name amongst the other block diagrams. I'm open to other ideas.

This made me realize that we should probably secure block diagrams by owner in the future. Right now, only one's own block diagrams are presented in mission-control, but others' could be loaded and edited via the console. 

This hasn't added the feature of launching mission control immediately into a saved block diagram. I'll work on that in a separate PR.