### PR TITLE
Add permissions check to block diagram API

### DIFF
--- a/mission_control/serializers.py
+++ b/mission_control/serializers.py
@@ -20,4 +20,5 @@ class BlockDiagramSerializer(serializers.ModelSerializer):
         """Meta class."""
 
         model = BlockDiagram
-        fields = ('id', 'user', 'name', 'content')
+        fields = '__all__'
+        read_only_fields = ('user',)

--- a/mission_control/tests/test_views.py
+++ b/mission_control/tests/test_views.py
@@ -6,6 +6,7 @@ from django.core.urlresolvers import reverse
 
 from mission_control.models import Rover, BlockDiagram
 
+import json
 import time
 
 
@@ -95,95 +96,50 @@ class TestBlockDiagramViewSet(BaseAuthenticatedTestCase):
     def test_bd(self):
         """Test the block diagram API view displays the correct items."""
         self.client.login(username='administrator', password='password')
-        bd = BlockDiagram.objects.create(
+        user = self.make_user()
+        bd1 = BlockDiagram.objects.create(
             user=self.admin,
             name='test',
             content='<xml></xml>'
         )
-        BlockDiagram.objects.create(
-            user=self.make_user(),
-            name='test',
+        bd2 = BlockDiagram.objects.create(
+            user=user,
+            name='test1',
             content='<xml></xml>'
         )
         response = self.get(reverse('mission-control:blockdiagram-list'))
         self.assertEqual(200, response.status_code)
-        self.assertEqual(1, len(response.json()))
-        self.assertEqual(response.json()[0]['id'], bd.id)
+        self.assertEqual(2, len(response.json()))
+        self.assertEqual(response.json()[0]['id'], bd1.id)
         self.assertEqual(response.json()[0]['user'], self.admin.id)
         self.assertEqual(response.json()[0]['name'], 'test')
         self.assertEqual(response.json()[0]['content'], '<xml></xml>')
+        self.assertEqual(response.json()[1]['id'], bd2.id)
+        self.assertEqual(response.json()[1]['user'], user.id)
+        self.assertEqual(response.json()[1]['name'], 'test1')
+        self.assertEqual(response.json()[1]['content'], '<xml></xml>')
 
     def test_bd_user_filter(self):
         """Test the block diagram API view filters on user correctly."""
         self.client.login(username='administrator', password='password')
         user1 = self.make_user('user1')
-        bd = BlockDiagram.objects.create(
+        BlockDiagram.objects.create(
             user=self.admin,
             name='test1',
             content='<xml></xml>'
         )
-        BlockDiagram.objects.create(
+        bd = BlockDiagram.objects.create(
             user=user1,
             name='test2',
             content='<xml></xml>'
         )
         response = self.get(
             reverse('mission-control:blockdiagram-list') +
-            '?user=' + str(self.admin.id))
+            '?user=' + str(user1.id))
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.json()))
         self.assertEqual(response.json()[0]['id'], bd.id)
-        self.assertEqual(response.json()[0]['user'], self.admin.id)
-        self.assertEqual(response.json()[0]['name'], 'test1')
-        self.assertEqual(response.json()[0]['content'], '<xml></xml>')
-
-    def test_bd_user_filter_user_restricted(self):
-        """Test the block diagram API view filters on user correctly."""
-        self.client.login(username='administrator', password='password')
-        user1 = self.make_user('user1')
-        BlockDiagram.objects.create(
-            user=self.admin,
-            name='test1',
-            content='<xml></xml>'
-        )
-        BlockDiagram.objects.create(
-            user=user1,
-            name='test2',
-            content='<xml></xml>'
-        )
-        response = self.get(
-            reverse(
-                'mission-control:blockdiagram-list') + '?user=' + str(user1.id))
-        self.assertEqual(200, response.status_code)
-        self.assertEqual(0, len(response.json()))
-
-    def test_bd_user_filter_superuser(self):
-        """Test the block diagram API view filters on user correctly."""
-        get_user_model().objects.create_superuser(
-            username='superuser',
-            email='superuser@example.com',
-            password='secret'
-        )
-        self.client.login(username='superuser', password='secret')
-        user1 = self.make_user('user1')
-        user2 = self.make_user('user2')
-        BlockDiagram.objects.create(
-            user=user1,
-            name='test1',
-            content='<xml></xml>'
-        )
-        bd2 = BlockDiagram.objects.create(
-            user=user2,
-            name='test2',
-            content='<xml></xml>'
-        )
-        response = self.get(
-            reverse(
-                'mission-control:blockdiagram-list') + '?user=' + str(user2.id))
-        self.assertEqual(200, response.status_code)
-        self.assertEqual(1, len(response.json()))
-        self.assertEqual(response.json()[0]['id'], bd2.id)
-        self.assertEqual(response.json()[0]['user'], user2.id)
+        self.assertEqual(response.json()[0]['user'], user1.id)
         self.assertEqual(response.json()[0]['name'], 'test2')
         self.assertEqual(response.json()[0]['content'], '<xml></xml>')
 
@@ -204,4 +160,45 @@ class TestBlockDiagramViewSet(BaseAuthenticatedTestCase):
         self.assertEqual(201, response.status_code)
         self.assertEqual(BlockDiagram.objects.last().user.id, self.admin.id)
         self.assertEqual(BlockDiagram.objects.last().name, data['name'])
-        self.assertEqual(BlockDiagram.objects.last().content, data['content'])
+
+    def test_bd_update_as_valid_user(self):
+        """Test updating block diagram as owner."""
+        self.client.login(username='administrator', password='password')
+        bd = BlockDiagram.objects.create(
+            user=self.admin,
+            name='test1',
+            content='<xml></xml>'
+        )
+        data = {
+            'name': 'test',
+        }
+        response = self.client.patch(
+            reverse(
+                'mission-control:blockdiagram-detail', kwargs={'pk': bd.pk}),
+            json.dumps(data), content_type='application/json')
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(BlockDiagram.objects.last().user.id, self.admin.id)
+        self.assertEqual(BlockDiagram.objects.last().name, 'test')
+
+    def test_bd_update_as_invalid_user(self):
+        """Test updating block diagram as another user."""
+        self.client.login(username='administrator', password='password')
+        user = self.make_user()
+        bd = BlockDiagram.objects.create(
+            user=user,
+            name='test1',
+            content='<xml></xml>'
+        )
+        data = {
+            'name': 'test',
+        }
+        response = self.client.patch(
+            reverse(
+                'mission-control:blockdiagram-detail', kwargs={'pk': bd.pk}),
+            json.dumps(data), content_type='application/json')
+        self.assertEqual(400, response.status_code)
+        self.assertEqual(
+            response.content,
+            b'["You may only modify your own block diagrams"]')
+        self.assertEqual(BlockDiagram.objects.last().user.id, user.id)
+        self.assertEqual(BlockDiagram.objects.last().name, 'test1')

--- a/mission_control/tests/test_views.py
+++ b/mission_control/tests/test_views.py
@@ -18,14 +18,20 @@ class TestHomeView(TestCase):
         self.assertEqual(200, response.status_code)
 
 
-class TestListView(TestCase):
-    """Tests the block diagram list view."""
+class BaseAuthenticatedTestCase(TestCase):
+    """Base class for all authenticated test cases."""
 
     def setUp(self):
         """Setup the tests."""
-        self.admin = get_user_model().objects.create(username='administrator')
-        self.admin.set_password('password')
-        self.admin.save()
+        self.admin = get_user_model().objects.create_user(
+            username='administrator',
+            email='admin@example.com',
+            password='password'
+        )
+
+
+class TestListView(BaseAuthenticatedTestCase):
+    """Tests the block diagram list view."""
 
     def test_list(self):
         """Test the block diagram list view displays the correct items."""
@@ -67,6 +73,7 @@ class TestRoverViewSet(TestCase):
             local_ip='8.8.8.8'
         )
         response = self.get(reverse('mission-control:rover-list'))
+        self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.json()))
         self.assertEqual(response.json()[0]['name'], 'rover')
         self.assertEqual(response.json()[0]['owner'], 'jimbo')
@@ -78,29 +85,86 @@ class TestRoverViewSet(TestCase):
             local_ip='8.8.8.8'
         )
         response = self.get(reverse('mission-control:rover-list'))
+        self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.json()))
 
 
-class TestBlockDiagramViewSet(TestCase):
+class TestBlockDiagramViewSet(BaseAuthenticatedTestCase):
     """Tests the block diagram API view."""
 
     def test_bd(self):
         """Test the block diagram API view displays the correct items."""
-        user = self.make_user()
+        self.client.login(username='administrator', password='password')
         bd = BlockDiagram.objects.create(
-            user=user,
+            user=self.admin,
+            name='test',
+            content='<xml></xml>'
+        )
+        BlockDiagram.objects.create(
+            user=self.make_user(),
             name='test',
             content='<xml></xml>'
         )
         response = self.get(reverse('mission-control:blockdiagram-list'))
+        self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.json()))
         self.assertEqual(response.json()[0]['id'], bd.id)
-        self.assertEqual(response.json()[0]['user'], user.id)
+        self.assertEqual(response.json()[0]['user'], self.admin.id)
         self.assertEqual(response.json()[0]['name'], 'test')
         self.assertEqual(response.json()[0]['content'], '<xml></xml>')
 
     def test_bd_user_filter(self):
         """Test the block diagram API view filters on user correctly."""
+        self.client.login(username='administrator', password='password')
+        user1 = self.make_user('user1')
+        bd = BlockDiagram.objects.create(
+            user=self.admin,
+            name='test1',
+            content='<xml></xml>'
+        )
+        BlockDiagram.objects.create(
+            user=user1,
+            name='test2',
+            content='<xml></xml>'
+        )
+        response = self.get(
+            reverse('mission-control:blockdiagram-list') +
+            '?user=' + str(self.admin.id))
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(1, len(response.json()))
+        self.assertEqual(response.json()[0]['id'], bd.id)
+        self.assertEqual(response.json()[0]['user'], self.admin.id)
+        self.assertEqual(response.json()[0]['name'], 'test1')
+        self.assertEqual(response.json()[0]['content'], '<xml></xml>')
+
+    def test_bd_user_filter_user_restricted(self):
+        """Test the block diagram API view filters on user correctly."""
+        self.client.login(username='administrator', password='password')
+        user1 = self.make_user('user1')
+        BlockDiagram.objects.create(
+            user=self.admin,
+            name='test1',
+            content='<xml></xml>'
+        )
+        BlockDiagram.objects.create(
+            user=user1,
+            name='test2',
+            content='<xml></xml>'
+        )
+        response = self.get(
+            reverse(
+                'mission-control:blockdiagram-list') + '?user=' + str(user1.id))
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(0, len(response.json()))
+
+    def test_bd_user_filter_superuser(self):
+        """Test the block diagram API view filters on user correctly."""
+        get_user_model().objects.create_superuser(
+            username='superuser',
+            email='superuser@example.com',
+            password='secret'
+        )
+        self.client.login(username='superuser', password='secret')
         user1 = self.make_user('user1')
         user2 = self.make_user('user2')
         BlockDiagram.objects.create(
@@ -116,8 +180,14 @@ class TestBlockDiagramViewSet(TestCase):
         response = self.get(
             reverse(
                 'mission-control:blockdiagram-list') + '?user=' + str(user2.id))
+        self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.json()))
         self.assertEqual(response.json()[0]['id'], bd2.id)
         self.assertEqual(response.json()[0]['user'], user2.id)
         self.assertEqual(response.json()[0]['name'], 'test2')
         self.assertEqual(response.json()[0]['content'], '<xml></xml>')
+
+    def test_bd_not_logged_in(self):
+        """Test the block diagram view denies unauthenticated user."""
+        response = self.get(reverse('mission-control:blockdiagram-list'))
+        self.assertEqual(403, response.status_code)

--- a/mission_control/tests/test_views.py
+++ b/mission_control/tests/test_views.py
@@ -191,3 +191,17 @@ class TestBlockDiagramViewSet(BaseAuthenticatedTestCase):
         """Test the block diagram view denies unauthenticated user."""
         response = self.get(reverse('mission-control:blockdiagram-list'))
         self.assertEqual(403, response.status_code)
+
+    def test_bd_create(self):
+        """Test creating block diagram sets user."""
+        self.client.login(username='administrator', password='password')
+        data = {
+            'name': 'test',
+            'content': '<xml></xml>'
+        }
+        response = self.client.post(
+            reverse('mission-control:blockdiagram-list'), data)
+        self.assertEqual(201, response.status_code)
+        self.assertEqual(BlockDiagram.objects.last().user.id, self.admin.id)
+        self.assertEqual(BlockDiagram.objects.last().name, data['name'])
+        self.assertEqual(BlockDiagram.objects.last().content, data['content'])

--- a/mission_control/views.py
+++ b/mission_control/views.py
@@ -52,3 +52,8 @@ class BlockDiagramViewSet(viewsets.ModelViewSet):
         if self.request.user.is_superuser:
             return BlockDiagram.objects.all()
         return BlockDiagram.objects.filter(user=self.request.user.id)
+
+    def perform_create(self, serializer):
+        """Perform the create operation."""
+        user = self.request.user
+        serializer.save(user=user)

--- a/mission_control/views.py
+++ b/mission_control/views.py
@@ -3,7 +3,7 @@ from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 from django_filters.rest_framework import DjangoFilterBackend
 from .models import Rover, BlockDiagram
-from rest_framework import viewsets
+from rest_framework import viewsets, permissions
 from rest_framework.response import Response
 from .serializers import RoverSerializer, BlockDiagramSerializer
 from mission_control.utils import remove_old_rovers
@@ -43,5 +43,12 @@ class BlockDiagramViewSet(viewsets.ModelViewSet):
 
     queryset = BlockDiagram.objects.all()
     serializer_class = BlockDiagramSerializer
+    permission_classes = (permissions.IsAuthenticated, )
     filter_backends = (DjangoFilterBackend,)
     filter_fields = ('user',)
+
+    def get_queryset(self):
+        """Get the queryset based on the authenticated user."""
+        if self.request.user.is_superuser:
+            return BlockDiagram.objects.all()
+        return BlockDiagram.objects.filter(user=self.request.user.id)


### PR DESCRIPTION
* Requires the user to be logged in to access the block diagram API.
* User can only access the user's block diagrams.
* Any superuser accounts can access all block diagrams through the API.
* Sets user to the logged in user that created the block diagram.